### PR TITLE
Refactor for security and to use WordPress APIs, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,41 @@ All OAuth2 options are controlled via the `Settings > Basecamp Integration` page
 How Does It Work?
 -----------------
 
-When users go to the WordPress login page (http://example.com/wp-login.php), they will be redirected immediately to Basecamp for authentication, based on the info provided in the settings page. After login, they will be redirected back and authenticated.
+Once the settings are configured, when users go to the WordPress login page (http://example.com/wp-login.php), they will be provided with a "Sign in with your Basecamp account" link, which when clicked will take the user to Basecamp for authentication. After login, they will be redirected back and authenticated.
 
-The user's organizations is compared against a specified organization ID. If they don't belong to that organization, authentication fails.
 
-If the user doesn't exist (checks against the email address), a new user will be added with the name & email provided by Basecamp. Also, if they are an administrator of the Basecamp organization, they will be given the administrator role in WordPress.
+If the user doesn't exist (checks against the email address), a new user will be added with the name & email provided by Basecamp.
+
+Also, if they are an administrator of the Basecamp organization, they will be given the administrator role in WordPress.
+
+The user's organizations is compared against a specified organization ID.
+
+* If they don't belong to that organization, they will be granted the `'subscriber'` role.
+* If they DO belong to the organization, they will be granted the `'contributor'` role.
+* if they are an administrator of the Basecamp organization, they will be given the '`administrator`' role.
+
+Each of these role defaults can be modifed through the use of the following WordPress filters:
+
+* `'wp_basecamp_default_user_level'`
+* `'wp_basecamp_default_organization_user_level'`
+* `'wp_basecamp_user_level_organization_admin'`
+
+So, to change the default role for users in your organization from `'contributor'` to `'author'`, add this snippet to your theme's functions.php file:
+
+```php
+function wp_basecamp_default_organization_user_level_to_author( $role ) {
+	return 'author';
+}
+add_filter( 'wp_basecamp_default_organization_user_level', 'wp_basecamp_default_organization_user_level_to_author' );
+```
+
+You can also completely disable Basecamp authentication for users who do not belong to your organization, by adding the following snippet:
+
+```php
+add_filter( 'wp_basecamp_default_user_level', '__return_false' );
+```
+
+Keep in mind, these roles will be applied when the user first logs in via Basecamp and their user is created in WordPress. After that first login, you can change their user-level, and it will apply for subsequent logins.
 
 Requirements
 ------------
@@ -27,6 +57,12 @@ Author
 + [@brandonwamboldt](http://twitter.com/brandonwamboldt)
 + [github.com/brandonwamboldt](http://github.com/brandonwamboldt)
 + [brandonwamboldt.ca](http://brandonwamboldt.ca)
+
+**Justin Sternberg**
+
++ [@jtsternberg](http://twitter.com/jtsternberg)
++ [github.com/jtsternberg](http://github.com/jtsternberg)
++ [dsgnwrks.pro](http://dsgnwrks.pro)
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ All OAuth2 options are controlled via the `Settings > Basecamp Integration` page
 How Does It Work?
 -----------------
 
-Once the settings are configured, when users go to the WordPress login page (http://example.com/wp-login.php), they will be provided with a "Sign in with your Basecamp account" link, which when clicked will take the user to Basecamp for authentication. After login, they will be redirected back and authenticated.
-
+Once the settings are configured, when users go to the WordPress login page (http://example.com/wp-login.php), they will be redirected immediately to Basecamp for authentication. After login, they will be redirected back and authenticated.
 
 If the user doesn't exist (checks against the email address), a new user will be added with the name & email provided by Basecamp.
 
@@ -43,6 +42,12 @@ add_filter( 'wp_basecamp_default_user_level', '__return_false' );
 ```
 
 Keep in mind, these roles will be applied when the user first logs in via Basecamp and their user is created in WordPress. After that first login, you can change their user-level, and it will apply for subsequent logins.
+
+There is also a filter for disabling the auto-redirect on wp-login. Once disabling, users will instead be provided with a "Sign in with your Basecamp account" link in the wp-login login form, which, when clicked, will take the user to Basecamp for authentication. To disable the auto-redirect:
+
+```php
+add_filter( 'wp_basecamp_auto_redirect_login', '__return_false' );
+```
 
 Requirements
 ------------

--- a/README.md
+++ b/README.md
@@ -43,16 +43,31 @@ add_filter( 'wp_basecamp_default_user_level', '__return_false' );
 
 Keep in mind, these roles will be applied when the user first logs in via Basecamp and their user is created in WordPress. After that first login, you can change their user-level, and it will apply for subsequent logins.
 
-There is also a filter for disabling the auto-redirect on wp-login. Once disabling, users will instead be provided with a "Sign in with your Basecamp account" link in the wp-login login form, which, when clicked, will take the user to Basecamp for authentication. To disable the auto-redirect:
+### Additional Filters
+
+Filter for disabling the auto-redirect on wp-login. Once disabling, users will instead be provided with a "Sign in with your Basecamp account" link in the wp-login login form, which, when clicked, will take the user to Basecamp for authentication. To disable the auto-redirect:
 
 ```php
 add_filter( 'wp_basecamp_auto_redirect_login', '__return_false' );
 ```
 
+Filter for modifying the auto-created usernames. By default it creates the username in the pattern of "first-last". If it finds a user in WordPress with that username, it will then append the Basecamp userid to the username, "first-last-5555555". The filter gets passed the array of identity information provided from the API, so if you preferred to change the username to the user's email, you could do so like:
+
+```php
+function wp_basecamp_username_email( $username, $identity ) {
+	if ( isset( $identity['email_address'] ) ) {
+		$username = $identity['email_address'];
+	}
+
+	return $username;
+}
+add_filter( 'wp_basecamp_username', 'wp_basecamp_username_email', 10, 2 );
+```
+
 Requirements
 ------------
 
-The OAuth2 library I'm using requires the [PHP cURL](http://www.php.net/manual/en/book.curl.php) extension to be installed.
+The OAuth2 library in use in this plugin requires the [PHP cURL](http://www.php.net/manual/en/book.curl.php) extension to be installed.
 
 Author
 ------

--- a/classes/admin.php
+++ b/classes/admin.php
@@ -36,8 +36,8 @@ class WordPressBasecampAdmin
     // Get the current settings
     $client_id       = get_option( 'wp:basecamp:client_id' );
     $client_secret   = get_option( 'wp:basecamp:client_secret' );
-    $auth_endpoint   = get_option( 'wp:basecamp:auth_endpoint', 'https://launchpad.37signals.com/authorization/new' );
-    $token_endpoint  = get_option( 'wp:basecamp:token_endpoint', 'https://launchpad.37signals.com/authorization/token' );
+    $auth_endpoint   = get_option( 'wp:basecamp:auth_endpoint', WP_BASECAMP_AUTH_ENDPOINT );
+    $token_endpoint  = get_option( 'wp:basecamp:token_endpoint', WP_BASECAMP_TOKEN_ENDPOINT );
     $organization_id = get_option( 'wp:basecamp:organization_id' );
     $redirect_uri    = wp_login_url();
 

--- a/classes/core.php
+++ b/classes/core.php
@@ -33,8 +33,14 @@ class WordPressBasecampCore {
    * Setup login form or redirect user.
    */
   public function login_init() {
-    // If requesting to not auto-redirect, then add a link to the login form.
-    if ( ! apply_filters( 'wp_basecamp_auto_redirect_login', true ) || isset( $_GET['code'] ) ) {
+    if (
+      // If requesting to not auto-redirect, then add a link to the login form.
+      ! apply_filters( 'wp_basecamp_auto_redirect_login', true )
+      // If we're coming back from basecamp w/ the code, don't redirect
+      || isset( $_GET['code'] )
+      // If we're in the middle of logging in traditionally, don't redirect
+      || ! empty( $_POST )
+    ) {
       // Add the link to the sign-in page
       return add_action( 'login_form', array( $this, 'printLoginLink' ) );
     }

--- a/classes/core.php
+++ b/classes/core.php
@@ -65,7 +65,7 @@ class WordPressBasecampCore
     $client->setAccessToken($response['result']['access_token']);
 
     // Get authorization info
-    $response = $client->fetch('https://launchpad.37signals.com/authorization.json');
+    $response = $client->fetch( WP_BASECAMP_AUTH_INFO_ENDPOINT );
 
     // Get the user's email
     $user_email = $response['result']['identity']['email_address'];
@@ -174,11 +174,11 @@ class WordPressBasecampCore
   }
 
   public function get_auth_endpoint() {
-    return get_option( 'wp:basecamp:auth_endpoint', 'https://launchpad.37signals.com/authorization/new' );
+    return get_option( 'wp:basecamp:auth_endpoint', WP_BASECAMP_AUTH_ENDPOINT );
   }
 
   public function get_token_endpoint() {
-    return get_option( 'wp:basecamp:token_endpoint', 'https://launchpad.37signals.com/authorization/token' );
+    return get_option( 'wp:basecamp:token_endpoint', WP_BASECAMP_TOKEN_ENDPOINT );
   }
 
 }

--- a/classes/core.php
+++ b/classes/core.php
@@ -142,6 +142,7 @@ class WordPressBasecampCore {
       if ($account['id'] == $organization_id) {
         $in_organization = true;
         $api_href        = $account['href'];
+        $user_level      = $bc_user_level;
         break;
       }
     }
@@ -173,7 +174,7 @@ class WordPressBasecampCore {
       'last_name'    => $last_name,
       'nickname'     => $full_name,
       'display_name' => $full_name,
-      'role'         => 1 == $response['result']['admin'] ? $bc_admin_level : $bc_user_level,
+      'role'         => 1 == $response['result']['admin'] ? $bc_admin_level : $user_level,
     );
 
     $new_user_id = wp_insert_user( $userdata );
@@ -187,7 +188,7 @@ class WordPressBasecampCore {
   }
 
   /**
-   * If we're on the WordPress login screen, add a Bascamp login link.
+   * If we're on the WordPress login screen, add a Basecamp login link.
    */
   public function printLoginLink() {
     if ( $client = $this->get_client() ) {

--- a/views/admin/options.php
+++ b/views/admin/options.php
@@ -10,40 +10,41 @@
   </p>
 
   <form method="post">
+    <?php wp_nonce_field( 'save-basecamp-settings', 'save-basecamp-settings' ); ?>
     <table class="form-table">
       <tbody>
         <tr valign="top">
           <th scope="row"><label for="api_client_id">Client ID</label></th>
           <td>
-            <input name="api_client_id" type="text" id="api_client_id" value="<?= $client_id ?>" class="regular-text code">
+            <input name="api_client_id" type="text" id="api_client_id" value="<?php echo esc_attr( $client_id ); ?>" class="regular-text code">
           </td>
         </tr>
 
         <tr valign="top">
           <th scope="row"><label for="api_client_secret">Client Secret</label></th>
           <td>
-            <input name="api_client_secret" type="text" id="api_client_secret" value="<?= $client_secret ?>" class="regular-text code">
+            <input name="api_client_secret" type="text" id="api_client_secret" value="<?php echo esc_attr( $client_secret ); ?>" class="regular-text code">
           </td>
         </tr>
 
         <tr valign="top">
           <th scope="row"><label for="api_redirect_uri">Redirect URI</label></th>
           <td>
-            <input name="api_redirect_uri" type="text" id="api_redirect_uri" value="<?= $redirect_uri ?>" class="regular-text" disabled>
+            <input name="api_redirect_uri" type="text" id="api_redirect_uri" value="<?php echo esc_attr( $redirect_uri ); ?>" class="regular-text" disabled>
           </td>
         </tr>
 
         <tr valign="top">
           <th scope="row"><label for="api_auth_endpoint">Auth Endpoint</label></th>
           <td>
-            <input name="api_auth_endpoint" type="text" id="api_auth_endpoint" value="<?= $auth_endpoint ?>" class="regular-text">
+            <input name="api_auth_endpoint" type="text" id="api_auth_endpoint" value="<?php echo esc_attr( $auth_endpoint ); ?>" class="regular-text">
           </td>
         </tr>
 
         <tr valign="top">
           <th scope="row"><label for="api_token_endpoint">Token Endpoint</label></th>
           <td>
-            <input name="api_token_endpoint" type="text" id="api_token_endpoint" value="<?= $token_endpoint ?>" class="regular-text">
+            <input name="api_token_endpoint" type="text" id="api_token_endpoint" value="<?php echo esc_attr( $token_endpoint ); ?>" class="regular-text">
           </td>
         </tr>
       </tbody>
@@ -56,7 +57,7 @@
         <tr valign="top">
           <th scope="row"><label for="organization_id">Organization ID</label></th>
           <td>
-            <input name="organization_id" type="text" id="organization_id" value="<?= $organization_id ?>" class="regular-text code">
+            <input name="organization_id" type="text" id="organization_id" value="<?php echo esc_attr( $organization_id ); ?>" class="regular-text code">
           </td>
         </tr>
       </tbody>

--- a/views/login/button.php
+++ b/views/login/button.php
@@ -1,0 +1,3 @@
+<p class="basecamp-signin" style="margin: 5px 0 10px;">
+  <a href="<?php echo esc_url( $login_url ); ?>">Sign in with your Basecamp account</a><br />
+</p>

--- a/wp-basecamp.php
+++ b/wp-basecamp.php
@@ -2,7 +2,7 @@
 
 /*
  * Plugin Name: Basecamp Integration
- * Author:      Brandon Wamboldt
+ * Author:      Brandon Wamboldt, Justin Sternberg
  * Author URI:  http://brandonwamboldt.ca/
  * Version:     1.0
  * Description: Provides integration with 37signals Basecamp (oAuth login and user syncing)

--- a/wp-basecamp.php
+++ b/wp-basecamp.php
@@ -8,6 +8,10 @@
  * Description: Provides integration with 37signals Basecamp (oAuth login and user syncing)
  */
 
+define( 'WP_BASECAMP_AUTH_ENDPOINT', 'https://launchpad.37signals.com/authorization/new' );
+define( 'WP_BASECAMP_TOKEN_ENDPOINT', 'https://launchpad.37signals.com/authorization/token' );
+define( 'WP_BASECAMP_AUTH_INFO_ENDPOINT', 'https://launchpad.37signals.com/authorization.json' );
+
 add_action('plugins_loaded', function() {
     require 'classes/admin.php';
     require 'classes/core.php';


### PR DESCRIPTION
This is a pretty major refactor, and I know it's hard to review. Basically, it contains:
- Cleanup for _some_ WordPress coding standards
- Added a nonce to the settings form to tighten security, as well as ensured the field values could only be saved on the settings page.
- Sanitized field values before saving to the DB
- Escaped field values before outputting to the form fields
- Set sane defaults for auth_endpoint and token_endpoint
- Added several WordPress filters to allow Devs to override the defaults (see readme)
- Allowed non-org users to be authenticated by default (to subscriber). This is a filtered value, and can be disabled.
- Allow basecamp login auto-redirect to be disabled via filter (see readme)
- Updated to use WordPress APIs for authentication, etc.
- Added a redirect "memory" so that after authentication, the user is redirected back to original location
- Moved multi-use code to separate methods

Let me know if you have any questions.

Related: #1 
